### PR TITLE
Add support for older shell versions (#29)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,6 @@
   "description": "Display a simple workspace indicator showing icons of apps open in it.\n\nUsage and customization:\n- Support for drag and drop: change an application workspace just dragging its icon\n- Right/Left click to focus application, Middle click to close\n- Workspaces scrolling: change active workspace scrolling hover the indicator\n- Toggle application icons desaturation\n- Show/Hide workspaces index label\n- Show/Hide active workspace and focused app indicator\n- Change indicator style and color\n- Support for multiple monitor (for both static and dynamic workspaces)\n- [NEW!] Hide empty workspaces\n- [NEW!] Rename workspaces directly from the extension (switch workspace to apply new name)\n",
   "uuid": "workspaces-by-open-apps@favo02.github.com",
   "url": "https://github.com/Favo02/workspaces-by-open-apps",
-  "version": "7",
-  "shell-version": [
-    "44"
-  ]
+  "version": "8",
+  "shell-version": [ "40", "41", "42", "43", "44" ]
 }


### PR DESCRIPTION
- add support for older shell versions in `metadata` (gnome shell 40, 41, 42, 43, 44)