### PR TITLE
CSS refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
 - **Group icons** of same application
 - **Ignore** applications (with regex)
 
+> [!TIP]
+> Customize CSS editing `stylesheet.css` file. Add more classes simply searching `css_*` variables in `extension.js`.
+
 <img src="https://github.com/Favo02/workspaces-by-open-apps/assets/59796435/29f066c6-b2e8-411d-8430-faf4d921db27" alt="Preview" height="40">
 
 <img src="https://github.com/Favo02/workspaces-by-open-apps/assets/59796435/72d6ea78-640a-4f1f-8c50-ddf5bb3baabb" alt="Preview" height="40">

--- a/src/extension.js
+++ b/src/extension.js
@@ -434,12 +434,12 @@ export default class WorkspacesByOpenApps extends Extension {
 
   /**
    * click on workspace handler
-   * @param actor actor clicked
+   * @param _ actor clicked (unused)
    * @param event click event
    */
-  _on_click_workspace(actor, event) {
+  _on_click_workspace(_, event) {
     // this._constants are not in scope
-    const LEFT_CLICK = 1, MIDDLE_CLICK = 2, RIGHT_CLICK = 3
+    const LEFT_CLICK = 1, RIGHT_CLICK = 3
 
     // left click: focus workspace or activate overview
     if (event.get_button() === LEFT_CLICK) {
@@ -492,10 +492,10 @@ export default class WorkspacesByOpenApps extends Extension {
 
   /**
    * click on application icon handler
-   * @param actor actor clicked
+   * @param _ actor clicked (unused)
    * @param event click event
    */
-  _on_click_application(actor, event) {
+  _on_click_application(_, event) {
     // this._constants are not in scope
     const LEFT_CLICK = 1, MIDDLE_CLICK = 2, RIGHT_CLICK = 3
 
@@ -522,10 +522,10 @@ export default class WorkspacesByOpenApps extends Extension {
 
   /**
    * scroll on workspace indicator handler
-   * @param actor actor scrolled on
+   * @param _ actor scrolled on (unused)
    * @param event click event
    */
-  _on_scroll_workspace(actor, event) {
+  _on_scroll_workspace(_, event) {
     // scroll direction
     let scroll_direction = event.get_scroll_direction()
 
@@ -557,7 +557,6 @@ export default class WorkspacesByOpenApps extends Extension {
 
     if (new_index >= 0 && new_index < workspace_manager.n_workspaces)
       workspace_manager.get_workspace_by_index(new_index).activate(Shell.Global.get().get_current_time())
-
   }
 
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -191,16 +191,17 @@ export default class WorkspacesByOpenApps extends Extension {
     if (this._settings.indicator_hide_empty && !is_active && windows.length === 0)
       return
 
-    // indicator styles
-    let style_classes = "workspace"
-    if (is_active) style_classes += " active"
-    if (!this._settings.indicator_show_active_workspace) style_classes += " no-indicator"
-    if (!this._settings.indicator_round_borders) style_classes += " no-rounded"
+    const css_inline_workspace = `border-color: ${this._settings.indicator_color}`
+
+    const css_classes_workspace =                         [ "wboa-workspace" ]
+    if (is_active)                                        css_classes_workspace.push("wboa-active")
+    if (!this._settings.indicator_show_active_workspace)  css_classes_workspace.push("wboa-no-indicator")
+    if (!this._settings.indicator_round_borders)          css_classes_workspace.push("wboa-no-rounded")
 
     // create indicator
     const indicator = new St.Bin({
-      style_class: style_classes,
-      style: `border-color: ${this._settings.indicator_color}`,
+      style: css_inline_workspace,
+      style_class: css_classes_workspace.join(" "),
       reactive: true,
       can_focus: true,
       track_hover: true,
@@ -353,15 +354,16 @@ export default class WorkspacesByOpenApps extends Extension {
         if (this._settings.apps_all_desaturate)
           texture.add_effect(new Clutter.DesaturateEffect())
 
-        // styles
-        let style_classes = "app"
-        if (is_focus) style_classes += " active"
-        if (!this._settings.indicator_show_focused_app) style_classes += " no-indicator"
-        if (!this._settings.indicator_round_borders) style_classes += " no-rounded"
+        const css_inline_app = `border-color: ${this._settings.indicator_color}`
+
+        const css_classes_app =                           [ "wboa-app" ]
+        if (is_focus)                                     css_classes_app.push("wboa-active")
+        if (!this._settings.indicator_show_focused_app)   css_classes_app.push("wboa-no-indicator")
+        if (!this._settings.indicator_round_borders)      css_classes_app.push("wboa-no-rounded")
 
         const icon = new St.Bin({
-          style_class: style_classes,
-          style: `border-color: ${this._settings.indicator_color}`,
+          style: css_inline_app,
+          style_class: css_classes_app.join(" "),
           reactive: true,
           can_focus: true,
           track_hover: true,
@@ -386,11 +388,13 @@ export default class WorkspacesByOpenApps extends Extension {
         // add icon texture to icon button
         icon.get_child().add_child(texture)
 
+        const css_classes_text = [ "wboa-app-group-text" ]
+
         // add x{occurrences} label to icon button (group same application)
         if ((this._settings.icons_group === 1) && (occurrences[win.get_pid()].count > 1)) {
           icon.get_child().add_child(new St.Label({
             text: `x${occurrences[win.get_pid()].count}`,
-            style_class: "text-group"
+            style_class: css_classes_text.join(" ")
           }))
         }
 
@@ -419,10 +423,12 @@ export default class WorkspacesByOpenApps extends Extension {
       indicator_text = (index+1).toString()
     }
 
+    const css_classes_label = [ "wboa-workspace-label" ]
+
     // add label to indicator
     button.get_child().insert_child_at_index(new St.Label({
       text: indicator_text,
-      style_class: "text"
+      style_class: css_classes_label.join(" ")
     }), 0)
   }
 
@@ -458,10 +464,12 @@ export default class WorkspacesByOpenApps extends Extension {
         return
       }
 
+      const css_classes_label = [ "wboa-workspace-label" ]
+
       // create text input
       const entry = new St.Entry({
         text: Meta.prefs_get_workspace_name(this._index),
-        style_class: "text",
+        style_class: css_classes_label.join(" ")
       })
 
       // connect typing event: update workspace name

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -1,42 +1,57 @@
-.workspace {
-  margin: 0px 5px;
+/* --- workspace --- */
+.wboa-workspace { /* workspace indicator */
+  padding: 0px;
+  margin-left: 6px;
+  margin-bottom: 2px;
 }
-
-.workspace.active {
+.wboa-workspace.wboa-active { /* active workspace */
   border-radius: 5px;
   border-bottom: 2px solid white;
+  margin-bottom: 0px;
+}
+.wboa-workspace.wboa-active.wboa-no-indicator {
+  border: none !important;
+  margin-bottom: 2px;
 }
 
-.text {
-  padding: 5px;
+/* --- workspace label --- */
+.wboa-workspace-label { /* label text (number or name) */
+  padding: 0px;
+  margin: 7px 3px;
   color: rgb(110, 110, 110);
   font-size: 12px;
 }
-
-.text-group {
-  padding: 7px 3px 5px 0px;
-  color: rgba(110, 110, 110, 0.58);
-  font-size: 12px;
-}
-
-.workspace.active .text,
-.workspace.active-no-indicator .text {
+.wboa-active .wboa-workspace-label { /* active workspace label */
   color: white;
 }
 
-.app.active {
-  border-top: 2px solid white;
+/* --- app --- */
+.wboa-app { /* app icon */
+  padding: 0px;
+  margin-top: 2px;
+}
+.wboa-app.wboa-active { /* active app */
   border-radius: 5px;
+  border-top: 2px solid white;
+  margin-top: 0px;
 }
-
-.app.active .text-group {
-  padding: 5px 3px 5px 0px;
-}
-
-.no-indicator {
+.wboa-app.wboa-active.wboa-no-indicator {
   border: none !important;
+  margin-top: 2px;
 }
 
-.no-rounded {
+/* --- apps group --- */
+.wboa-app-group-text { /* group text (x2, x3, ...) */
+  padding: 0px;
+  margin: 5px 3px 5px 0px;
+  color: rgba(110, 110, 110, 0.58);
+  font-size: 12px;
+}
+.wboa-active .wboa-app-group-text { /* active group */
+  color: white;
+}
+
+/* --- common --- */
+.wboa-no-rounded {
   border-radius: 0px !important;
 }


### PR DESCRIPTION
- Rename CSS classes (add `wboa-` before each class to prevent conflicts with other extensions) (#59)
- Various CSS fixes
- General refactor: remove unused variables