### PR TITLE
Improve styling and fix issues #14 and #26

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -205,7 +205,12 @@ export default class WorkspacesByOpenApps extends Extension {
       reactive: true,
       can_focus: true,
       track_hover: true,
-      child: new St.BoxLayout()
+      child: new St.BoxLayout({
+        style_class: "panel-button",
+        reactive: true,
+        can_focus: true,
+        track_hover: true
+      })
     })
     this._indicators.push(indicator)
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -24,7 +24,7 @@ export default class WorkspacesByOpenApps extends Extension {
       GROUP_AND_SHOW_COUNT: 1,
       GROUP_WITHOUT_COUNT: 2,
       NO_LIMIT: 100,
-      LOW_OPACITY: 150,
+      LOW_OPACITY: 175,
       ICONS_SIZE: 10,
       TEXTURES_SIZE: 20
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -36,13 +36,13 @@ export default class WorkspacesByOpenApps extends Extension {
 
   /** disable extension: destroy everything */
   disable() {
+    this._disconnect_signals() // disconnect signals
+    
     this._raw_settings = null
     this._settings = null
     this._constants = null
     this._indicators.splice(0).forEach(i => i.destroy()) // destroy current indicators
     this._indicators = null
-
-    this._disconnect_signals() // disconnect signals
   }
 
   /** parse raw settings object into a better formatted object */
@@ -97,6 +97,8 @@ export default class WorkspacesByOpenApps extends Extension {
     this._sig_dp1 = display.connect("restacked", () => this._render())
     this._sig_dp2 = display.connect("window-left-monitor", () => this._render())
     this._sig_dp3 = display.connect("window-entered-monitor", () => this._render())
+    
+    this._sig_sett = this._raw_settings.connect("changed", () => this._render())
   }
 
   /** disconnect signals */
@@ -116,6 +118,8 @@ export default class WorkspacesByOpenApps extends Extension {
     display.disconnect(this._sig_dp1)
     display.disconnect(this._sig_dp2)
     display.disconnect(this._sig_dp3)
+    
+    this._raw_settings.disconnect(this._sig_sett)
   }
 
   /** render indicators: destroy current indicators and rebuild */

--- a/src/extension.js
+++ b/src/extension.js
@@ -38,6 +38,8 @@ export default class WorkspacesByOpenApps extends Extension {
   disable() {
     this._disconnect_signals() // disconnect signals
     
+    main.panel.statusArea["activities"]?.show() // restore activities
+    
     this._raw_settings = null
     this._settings = null
     this._constants = null

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -27,8 +27,11 @@
 
 /* --- app --- */
 .wboa-app { /* app icon */
-  padding: 0px;
+  padding-top: 4px;
   margin-top: 2px;
+}
+.wboa-app:hover, .wboa-app:focus {
+  padding-top: 0px;
 }
 .wboa-app.wboa-active { /* active app */
   border-radius: 5px;


### PR DESCRIPTION
New Features:
- Add panel button styles to the workspace indicators: This helps to better integrate them with the panel making them look similar to other buttons and also allow hover highlights. Especially helpful for custom user themes or extensions like 'Open Bar'.
- Add hover styles to app-icons: This gives feedback for hovering over an app-icon. It makes the indicators more interactive and responsive. It is done using css padding that makes the icons move (and grow depending on panel size) on hover.
- Low Opacity icons: A tiny change to Low opacity constant, from 150 to 175. I noticed some icons not properly visible under low opacity, so.

Fixes:
- Fixes for issues #14 and #26: Basically, any changes made from the Preferences window will reflect immediately.
- Fix for activities: On disable, the original Activities button was not restored so fixed that.