### PR TITLE
Get rid of sudo requirement in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,9 +22,9 @@ fi
 echo "Removing the extension directory..."
 
 # Remove current extension version
-sudo rm -rf "$EXTENSION_PATH"
+rm -rf "$EXTENSION_PATH"
 
-# If 'sudo' or 'rm' failed, exit
+# If 'rm' failed, exit
 if [ $? -ne 0 ]; then
     echo "Removal of the extension directory failed. Exiting."
     exit 1


### PR DESCRIPTION
Sudo is not needed to clear the extension path because it'll probably be in the home directory and running the script to install the extension globally (`XDG_DATA_HOME=/usr/share ./install.sh`) as an unprivileged user without sudo would fail anyway.