### PR TITLE
Group icons by app ID instead of window PID

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -64,12 +64,12 @@ export default class Application extends St.BoxLayout {
     const css_style_text = `font-size: ${this._settings.size_labels}px`
     const css_classes_text = [ "wboa-label" ]
 
-    if ((this._settings.icons_group === 1) && (occurrences.get(window.get_pid()).count > 1)) {
+    if ((this._settings.icons_group === 1) && (occurrences.get(window.app_id).count > 1)) {
       this.add_child(new St.Label({
         style: css_style_text,
         style_class: css_classes_text.join(" "),
         y_align: Clutter.ActorAlign.CENTER,
-        text: `x${occurrences.get(window.get_pid()).count}`
+        text: `x${occurrences.get(window.app_id).count}`
       }))
     }
   }

--- a/src/extension.js
+++ b/src/extension.js
@@ -194,6 +194,9 @@ export default class WorkspacesByOpenApps extends Extension {
         const app = Shell.WindowTracker.get_default().get_window_app(win)
         if (!app) return false
 
+        // store app id on window
+        win.app_id = app.get_id()
+
         // apps on all workspaces (for normal workspace indicator)
         if (!is_other_monitor && win.is_on_all_workspaces()) return false
 
@@ -235,7 +238,7 @@ export default class WorkspacesByOpenApps extends Extension {
       margin-right: ${this._settings.spacing_workspace_right}px;
       `
 
-    const css_classes_workspace = [ "wboa-workspace" ]
+    const css_classes_workspace = ["wboa-workspace"]
     if (this._settings.indicator_swap_position) {
       css_classes_workspace.push("wboa-top")
     } else {
@@ -245,7 +248,7 @@ export default class WorkspacesByOpenApps extends Extension {
     if (!this._settings.indicator_show_active_workspace) css_classes_workspace.push("wboa-no-indicator")
     if (this._settings.indicator_round_borders) css_classes_workspace.push("wboa-rounded")
 
-    const css_classes_panel = [ "panel-button", "wboa-panel-rounded" ]
+    const css_classes_panel = ["panel-button", "wboa-panel-rounded"]
     if (!this._settings.indicator_round_borders) css_classes_panel.push("wboa-no-rounded")
 
     return new Workspace(this._settings, workspace, windows, index, is_active, is_other_monitor, css_classes_panel, css_inline_workspace, css_classes_workspace)

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -109,7 +109,7 @@ export default class Workspace extends St.Bin {
 
     if (this._settings.icons_group !== CONSTANTS.OFF) {
       for (const window of windows) {
-        const id = window.get_pid()
+        const id = window.app_id
         const get_or_default = occurrences.get(id) ?? { count: 0, focus: false, not_minimized: false }
 
         occurrences.set(id, {
@@ -131,8 +131,8 @@ export default class Workspace extends St.Bin {
   _remove_duplicates(windows) {
     const seen = new Set()
     return windows.filter(win => {
-      if (seen.has(win.get_pid())) return false
-      seen.add(win.get_pid())
+      if (seen.has(win.app_id)) return false
+      seen.add(win.app_id)
       return true
     })
   }
@@ -151,7 +151,7 @@ export default class Workspace extends St.Bin {
     const app_icon = app.create_icon_texture(this._settings.size_app_icon)
 
     // effects for not focused apps
-    const is_focus = window.has_focus() || occurrences.get(window.get_pid())?.focus
+    const is_focus = window.has_focus() || occurrences.get(window.app_id)?.focus
     if (!is_focus) {
       // reduce opacity
       if (this._settings.apps_inactive_effect === CONSTANTS.REDUCE_OPACITY) {
@@ -164,7 +164,7 @@ export default class Workspace extends St.Bin {
     }
 
     // effects for minimized apps
-    const is_not_minimized = !window.is_hidden() || occurrences.get(window.get_pid())?.not_minimized
+    const is_not_minimized = !window.is_hidden() || occurrences.get(window.app_id)?.not_minimized
     if (!is_not_minimized) {
       // reduce opacity
       if (this._settings.apps_minimized_effect === CONSTANTS.REDUCE_OPACITY) {
@@ -187,7 +187,7 @@ export default class Workspace extends St.Bin {
       margin-right: ${this._settings.spacing_app_right}px;
     `
 
-    const css_classes_app = [ "wboa-app" ]
+    const css_classes_app = ["wboa-app"]
     if (this._settings.indicator_swap_position) {
       css_classes_app.push("wboa-bottom")
     } else {
@@ -247,7 +247,7 @@ export default class Workspace extends St.Bin {
     }
     // default text: index
     else {
-      indicator_text = (index+1).toString()
+      indicator_text = (index + 1).toString()
     }
 
     const css_style_label = `
@@ -257,7 +257,7 @@ export default class Workspace extends St.Bin {
       margin-top: ${this._settings.spacing_label_top}px;
       margin-bottom: ${this._settings.spacing_label_bottom}px;
     `
-    const css_classes_label = [ "wboa-label" ]
+    const css_classes_label = ["wboa-label"]
 
     // add label to indicator
     this.get_child().insert_child_at_index(new St.Label({
@@ -299,7 +299,7 @@ export default class Workspace extends St.Bin {
         return
       }
 
-      const css_classes_label = [ "wboa-label" ]
+      const css_classes_label = ["wboa-label"]
 
       // create text input
       const entry = new St.Entry({


### PR DESCRIPTION
Hello, and thanks for a great extension!

I find the icon-group functionality to be a bit off, or at least it's not working as I expect it to.

For instance, VSCode groups its icons just fine, but Alacritty does not group at all. After digging around in the extension code I see that's due to the fact that grouping is done by window PID, which often vary between instances of an app.

For me, wanting only one icon per app, I changed the code to group by app ID instead. Not sure if it's the best solution, but it works for me, for now.

If this PR is something you want please help yourself to a merge, otherwise just drop it.

Cheers!