### PR TITLE
chore(extension): add support for GNOME Shell 48 in metadata.json

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,5 +5,5 @@
   "settings-schema": "org.gnome.shell.extensions.workspaces-indicator-by-open-apps",
   "url": "https://github.com/Favo02/workspaces-by-open-apps",
   "version": "20",
-  "shell-version": [ "45", "46", "47" ]
+  "shell-version": [ "45", "46", "47", "48" ]
 }


### PR DESCRIPTION
Added GNOME Shell 48 to the shell-version array in metadata.json to ensure compatibility with Fedora 42 and future GNOME releases.