### PR TITLE
Use dynamicly generated font color for workspace name labels

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -245,7 +245,6 @@ export default class WorkspacesByOpenApps extends Extension {
     } else {
       css_classes_workspace.push("wboa-bottom")
     }
-    if (is_active) css_classes_workspace.push("wboa-active")
     if (!this._settings.indicator_show_active_workspace) css_classes_workspace.push("wboa-no-indicator")
     if (this._settings.indicator_round_borders) css_classes_workspace.push("wboa-rounded")
 

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -29,9 +29,6 @@
 
 /* --- labels (workspace name and apps count) --- */
 /* label size managed by size-workspace-label setting */
-.wboa-active > .wboa-label {
-  color: rgba(255, 255, 255, 1) !important;
-}
 
 /* --- workspace indicator --- */
 /* workspace horizontal spacing is managed by spacing-workspace-{left, right} setttings */
@@ -41,9 +38,6 @@
 
 /* --- workspace label --- */
 /* workspace label spacing managed by spacing-label-{left, right, top, bottom} settings */
-.wboa-workspace > .wboa-label {
-  color: rgba(255, 255, 255, 0.5);
-}
 
 /* --- app icon --- */
 /* app icon size managed by size-app-icon setting */
@@ -59,7 +53,6 @@
 
 /* --- apps group label (x2, x3, ...) --- */
 .wboa-app > .wboa-label {
-  color: rgba(255, 255, 255, 0.4);
   /* space horizontally app groups */
   margin-right: 2px;
 }
@@ -85,13 +78,10 @@
   /* simulate presence of active indicator */
   margin-top: 2px;
 }
-.wboa-top.wboa-active {
-  border-top: 2px solid white;
-  /* disable simulation of presence of active indicator */
-  margin-top: 0px;
-}
+
 .wboa-top.wboa-no-indicator {
   border: none !important;
+  color: unset;
   /* simulate presence of active indicator */
   margin-top: 2px;
 }
@@ -102,13 +92,10 @@
   /* simulate presence of active indicator */
   margin-bottom: 2px;
 }
-.wboa-bottom.wboa-active {
-  border-bottom: 2px solid white;
-  /* disable simulation of presence of active indicator */
-  margin-bottom: 0px;
-}
+
 .wboa-bottom.wboa-no-indicator {
   border: none !important;
+  color: unset;
   /* simulate presence of active indicator */
   margin-bottom: 2px;
 }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -33,6 +33,7 @@ export default class Workspace extends St.Bin {
     this._settings = settings
     this._index = index
     this._workspace = workspace
+    this._is_active = is_active
 
     // setup signals
     this._setup_signals()
@@ -251,12 +252,35 @@ export default class Workspace extends St.Bin {
       indicator_text = (index + 1).toString()
     }
 
+    // dynamicly create style instead of using hardcoded css
+    let panel = main.panel
+    let color_rgba = null
+    let alpha = this._is_active ? 1 : 0.5
+    if (panel && panel.get_theme_node) {
+      try {
+        let gdkColor = panel.get_theme_node().get_foreground_color()
+        if (gdkColor) {
+          // gdkColor is Clutter.Color or Gdk.RGBA, both have r,g,b,a in 0-255 or 0-1
+          let r = Math.round((gdkColor.red !== undefined ? gdkColor.red : gdkColor.r) * (gdkColor.red !== undefined ? 1 : 255))
+          let g = Math.round((gdkColor.green !== undefined ? gdkColor.green : gdkColor.g) * (gdkColor.green !== undefined ? 1 : 255))
+          let b = Math.round((gdkColor.blue !== undefined ? gdkColor.blue : gdkColor.b) * (gdkColor.blue !== undefined ? 1 : 255))
+          let a = (gdkColor.alpha !== undefined ? gdkColor.alpha : (gdkColor.a !== undefined ? 1 : 1))
+          if (a > 1) a = a / 255
+          color_rgba = `rgba(${r},${g},${b},${alpha})`
+        }
+      } catch (e) {
+        // do nothing but log error
+        log(`[wboa] label color_rgba error: ${e}`)
+      }
+    }
+
     const css_style_label = `
       font-size: ${this._settings.size_labels}px;
       margin-left: ${this._settings.spacing_label_left}px;
       margin-right: ${this._settings.spacing_label_right}px;
       margin-top: ${this._settings.spacing_label_top}px;
       margin-bottom: ${this._settings.spacing_label_bottom}px;
+      ${color_rgba ? `color: ${color_rgba};` : ''}
     `
     const css_classes_label = ["wboa-label"]
 


### PR DESCRIPTION
`opacity: x` and `filter: opacity(x)` don't work in GNOME Shell. Therefore, this commit fixes #115 through deprecating the `wboa-active` CSS class and switching to an implementation utilizing the GNOME Shell API to dynamicly get the forground color.

There is a known issue that after this modification, active workspace indicator no longer work. For now I don't really have any more time to figure this out, so there will be a fix some time in the future.

Be advised that I don't have any experience in developing GNOME Shell extensions. 
**HUGE MISTAKES COULD'VE BEEN MADE**, but this is working for me now. 