### PR TITLE
Add windows sorting setting

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -93,6 +93,7 @@ export default class WorkspacesByOpenApps extends Extension {
 
       icons_limit: rs.get_int("icons-limit"),
       icons_group: rs.get_enum("icons-group"),
+      windows_sort_method: rs.get_string("windows-sort-method"),
       icons_ignored: rs.get_strv("icons-ignored"),
       log_apps_id: rs.get_boolean("log-apps-id"),
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1107,6 +1107,25 @@ export default class WorkspacesByOpenAppsPrefs extends ExtensionPreferences {
     row.activatable_widget = widget
     group.add(row)
 
+    row = new Adw.ActionRow({
+      title: "Sort windows by",
+      subtitle: "Method to sort application icons within each workspace",
+    })
+    widget = new Gtk.ComboBoxText({
+      valign: Gtk.Align.CENTER,
+    })
+    widget.append("WINDOW ID", "Window ID (default)")
+    widget.append("COORDINATES", "Window coordinates (top-left)")
+    settings.bind(
+      "windows-sort-method",
+      widget,
+      "active-id",
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+    row.add_suffix(widget)
+    row.activatable_widget = widget
+    group.add(row)
+
     return group
   }
 

--- a/src/schemas/org.gnome.shell.extensions.workspaces-indicator-by-open-apps.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.workspaces-indicator-by-open-apps.gschema.xml
@@ -22,6 +22,11 @@
     <value value="2" nick="GROUP WITHOUT COUNT"/>
   </enum>
 
+  <enum id="org.gnome.shell.extensions.workspaces-indicator-by-open-apps.enum-windows-sort">
+    <value value="0" nick="WINDOW ID"/>
+    <value value="1" nick="COORDINATES"/>
+  </enum>
+
   <schema id="org.gnome.shell.extensions.workspaces-indicator-by-open-apps"
     path="/org/gnome/shell/extensions/workspaces-indicator-by-open-apps/">
 
@@ -295,6 +300,12 @@
       <default>"OFF"</default>
       <summary>Group icons of same application</summary>
       <description>Show only one icon for each application in the workspace indicator</description>
+    </key>
+
+    <key name="windows-sort-method" enum="org.gnome.shell.extensions.workspaces-indicator-by-open-apps.enum-windows-sort">
+      <default>"WINDOW ID"</default>
+      <summary>Windows sorting method</summary>
+      <description>Method to sort application icons within each workspace</description>
     </key>
 
     <key name="icons-ignored" type="as">

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -88,20 +88,27 @@ export default class Workspace extends St.Bin {
       icons_limit = this._settings.icons_limit
     }
 
-    windows
-      .sort((w1, w2) => {
-        // sort by focus and id
-        if (w1.has_focus()) return -1
-        if (w2.has_focus()) return 1
-        return w1.get_id() - w2.get_id()
-      })
-      .slice(0, icons_limit) // limit icons
-      .sort((w1, w2) => w1.get_id() - w2.get_id()) // sort by id only
-      .forEach((window) => {
-        // create app indicator and add to workspace
-        const app_container = this._create_application(window, occurrences)
-        this.get_child().add_child(app_container)
-      })
+    // 1. sort by focus first to ensure the focused window is not sliced out
+    const focusedWindows = windows.filter((w) => w.has_focus())
+    const unfocusedWindows = windows.filter((w) => !w.has_focus())
+    const focusSortedWindows = [...focusedWindows, ...unfocusedWindows]
+
+    // 2. slice to apply the icons limit
+    let slicedWindows = focusSortedWindows.slice(0, icons_limit)
+
+    // 3. always sort by window ID first
+    slicedWindows = slicedWindows.sort((w1, w2) => w1.get_id() - w2.get_id())
+
+    // 4. if coordinates sort is selected, apply it on the sliced array
+    if (this._settings.windows_sort_method === "COORDINATES") {
+      slicedWindows = this._sortByCoordinates(slicedWindows)
+    }
+
+    slicedWindows.forEach((window) => {
+      // create app indicator and add to workspace
+      const app_container = this._create_application(window, occurrences)
+      this.get_child().add_child(app_container)
+    })
 
     // render + icon (for icon limit)
     if (windows.length > icons_limit) {
@@ -112,6 +119,54 @@ export default class Workspace extends St.Bin {
       })
       plus_icon.set_opacity(CONSTANTS.LOW_OPACITY)
       this.get_child().add_child(plus_icon)
+    }
+  }
+
+  /**
+   * Sort windows by their screen coordinates (top-left corner)
+   * Sorts by Y coordinate rounded to nearest 10% of screen width,
+   * then by X coordinate for windows at similar heights
+   * @param {Meta.Window[]} windows windows to sort
+   * @returns {Meta.Window[]} sorted windows
+   */
+  _sortByCoordinates(windows) {
+    try {
+      // Get screen dimensions for calculating the rounding threshold
+      const display = global.display || Shell.Global.get().get_display()
+      const geometry = display.get_monitor_geometry(0)
+      const roundingThreshold = Math.round((geometry.width || 1920) * 0.1) // 10% of screen width
+
+      return windows.sort((w1, w2) => {
+        try {
+          const rect1 = w1.get_frame_rect()
+          const rect2 = w2.get_frame_rect()
+
+          // Handle invalid frame rects
+          if (!rect1 || !rect2) {
+            return 0
+          }
+
+          // Round Y coordinates to nearest 10% of screen width
+          const y1Rounded =
+            Math.round(rect1.y / roundingThreshold) * roundingThreshold
+          const y2Rounded =
+            Math.round(rect2.y / roundingThreshold) * roundingThreshold
+
+          // Sort by Y (vertical position)
+          if (y1Rounded !== y2Rounded) {
+            return y1Rounded - y2Rounded
+          }
+
+          // If Y is similar, sort by X (horizontal position)
+          return rect1.x - rect2.x
+        } catch (e) {
+          console.error("Error sorting by coordinates:", e)
+          return 0
+        }
+      })
+    } catch (e) {
+      console.error("Error in _sortByCoordinates:", e)
+      return windows // Return unsorted windows on error
     }
   }
 


### PR DESCRIPTION
Add new 'windows-sort-method' setting to enable sorting application icons by window screen coordinates (top-left corner). Windows are sorted by Y coordinate (rounded to 10% of screen width) then by X coordinate for windows at similar heights. This provides more intuitive spatial ordering than the default window ID sorting.

#138 