### PR TITLE
[CRITICAL] Fix DnD freezes gnome shell

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -199,11 +199,8 @@ export default class Application extends St.BoxLayout {
     this.disconnect(this._sig_click)
     this.disconnect(this._sig_touch)
 
-    // cleanup draggable
-    if (this._draggable) {
-      this._draggable.destroy()
-      this._draggable = null
-    }
+    // cleanup draggable reference (draggable itself is managed by the dnd module)
+    this._draggable = null
 
     super.destroy()
   }


### PR DESCRIPTION
- Remove invalid draggable.destroy() call that caused TypeError when drag ends The draggable object from dnd.makeDraggable() is managed by the dnd module and does not have a destroy() method. This was causing the drag operation to fail and lock all GNOME input.

Fixes #141