### PR TITLE
fix(extension): ignore desktop windows

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -245,6 +245,9 @@ export default class WorkspacesByOpenApps extends Extension {
     // undefined window
     if (!win) return false
 
+    // desktop windows are shell components, not user applications
+    if (win.get_window_type() === Meta.WindowType.DESKTOP) return false
+
     // undefined app
     const app = Shell.WindowTracker.get_default().get_window_app(win)
     if (!app) return false
@@ -401,6 +404,9 @@ export default class WorkspacesByOpenApps extends Extension {
         // undefined app
         const app = Shell.WindowTracker.get_default().get_window_app(win)
         if (!app) return false
+
+        // desktop windows are shell components, not user applications
+        if (win.get_window_type() === Meta.WindowType.DESKTOP) return false
 
         // store app id on window
         win.app_id = app.get_id()


### PR DESCRIPTION
## Problem

On GNOME Shell 50, Desktop Icons NG (DING) desktop windows can be
reported as being visible on all workspaces. The extension consequently
renders an `ALL` indicator containing a generic gear icon.

Disabling DING makes the unwanted indicator disappear.

## Change

Exclude `Meta.WindowType.DESKTOP` windows from:

- workspace indicator rendering;
- dynamic window-title length calculation.

Desktop windows are shell components rather than user applications and
should not be displayed by the workspace indicator.

## Testing

Tested on GNOME Shell 50 with:

- Desktop Icons NG enabled;
- three fixed workspaces;
- regular windows across different workspaces;
- a regular window intentionally configured to appear on all workspaces.

The DING desktop icon no longer appears, while legitimate all-workspace
windows continue to appear in `ALL`.
